### PR TITLE
Rename footer-social class to footer-links to avoid uBlock filters

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -58,7 +58,7 @@
     </main>
     <hr class="divider">
     <footer class="site-footer">
-      <div class="footer-social">
+      <div class="footer-links">
         <a href="https://github.com/clarmso" aria-label="GitHub"><img src="{{ site.baseurl }}/assets/icons/social/github.svg" alt="GitHub"></a>
         <a href="https://mastodon.online/@clarmso" aria-label="Mastodon"><img src="{{ site.baseurl }}/assets/icons/social/mastodon.svg" alt="Mastodon"></a>
         <a href="https://bsky.app/profile/clarmso.ca/" aria-label="Bluesky"><img src="{{ site.baseurl }}/assets/icons/social/bluesky.svg" alt="Bluesky"></a>

--- a/assets/style.css
+++ b/assets/style.css
@@ -153,20 +153,20 @@ a:hover, a:focus {
   color: inherit;
 }
 
-.footer-social {
+.footer-links {
   display: flex;
   justify-content: center;
   gap: 1em;
   margin-bottom: 0.5em;
 }
 
-.footer-social img {
+.footer-links img {
   width: 1.4em;
   height: 1.4em;
   filter: brightness(0);
 }
 
-html.dark-mode .footer-social img {
+html.dark-mode .footer-links img {
   filter: brightness(0) invert(1);
 }
 


### PR DESCRIPTION
uBlock Origin's social blocking filter lists target elements with 'social' in their class names (e.g. `footer-social`) and links to sites like LinkedIn, causing the footer social icons to be hidden.

**Changes:**
- Renamed `.footer-social` → `.footer-links` in `_layouts/default.html` and `assets/style.css`