### PR TITLE
Move social media links from footer to top navigation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -47,6 +47,12 @@
         <a href="/projects">Projects</a>
       </div>
       <div class="nav-controls">
+        <div class="nav-social">
+          <a href="https://github.com/clarmso" aria-label="GitHub"><img src="{{ site.baseurl }}/assets/icons/social/github.svg" alt="GitHub"></a>
+          <a href="https://mastodon.online/@clarmso" aria-label="Mastodon"><img src="{{ site.baseurl }}/assets/icons/social/mastodon.svg" alt="Mastodon"></a>
+          <a href="https://bsky.app/profile/clarmso.ca/" aria-label="Bluesky"><img src="{{ site.baseurl }}/assets/icons/social/bluesky.svg" alt="Bluesky"></a>
+          <a href="https://www.linkedin.com/in/clarmso/" aria-label="LinkedIn"><img src="{{ site.baseurl }}/assets/icons/social/linkedin.svg" alt="LinkedIn"></a>
+        </div>
         <button id="theme-toggle" aria-label="Toggle theme">
           <img id="sun-icon" src="{{ site.baseurl }}/assets/icons/sun.svg" alt="Light Mode">
           <img id="moon-icon" src="{{ site.baseurl }}/assets/icons/moon.svg" alt="Dark Mode">
@@ -58,12 +64,6 @@
     </main>
     <hr class="divider">
     <footer class="site-footer">
-      <div class="footer-links">
-        <a href="https://github.com/clarmso" aria-label="GitHub"><img src="{{ site.baseurl }}/assets/icons/social/github.svg" alt="GitHub"></a>
-        <a href="https://mastodon.online/@clarmso" aria-label="Mastodon"><img src="{{ site.baseurl }}/assets/icons/social/mastodon.svg" alt="Mastodon"></a>
-        <a href="https://bsky.app/profile/clarmso.ca/" aria-label="Bluesky"><img src="{{ site.baseurl }}/assets/icons/social/bluesky.svg" alt="Bluesky"></a>
-        <a href="https://www.linkedin.com/in/clarmso/" aria-label="LinkedIn"><img src="{{ site.baseurl }}/assets/icons/social/linkedin.svg" alt="LinkedIn"></a>
-      </div>
       <p class="footer-copyright">&copy; {{ site.time | date: '%Y' }} Clare So</p>
     </footer>
 </body>

--- a/assets/style.css
+++ b/assets/style.css
@@ -80,6 +80,22 @@ nav {
   gap: 10px;
 }
 
+.nav-social {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.nav-social img {
+  width: 1.3em;
+  height: 1.3em;
+  filter: brightness(0);
+}
+
+html.dark-mode .nav-social img {
+  filter: brightness(0) invert(1);
+}
+
 #nav-links {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
Moves the GitHub, Mastodon, Bluesky, and LinkedIn icons from the footer into the top nav bar (right side, next to the theme toggle). Removes the footer social links section and adds `.nav-social` CSS with proper dark mode support.