### PR TITLE
Fix nav social icons: horizontal layout and monochrome filter

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -82,18 +82,24 @@ nav {
 
 .nav-social {
   display: flex;
+  flex-direction: row;
   align-items: center;
   gap: 8px;
+}
+
+.nav-social a {
+  display: flex;
+  align-items: center;
 }
 
 .nav-social img {
   width: 1.3em;
   height: 1.3em;
-  filter: brightness(0);
+  filter: brightness(0) saturate(0);
 }
 
 html.dark-mode .nav-social img {
-  filter: brightness(0) invert(1);
+  filter: brightness(0) saturate(0) invert(1);
 }
 
 #nav-links {


### PR DESCRIPTION
Fixes two issues with the social icons in the top navigation:
- Icons were stacking vertically instead of displaying in a row
- Icons were showing brand colors instead of monochrome

Changes: added explicit `flex-direction: row` to `.nav-social`, added `.nav-social a` flex alignment, and updated filter to `brightness(0) saturate(0)` to properly strip hardcoded SVG fill colors.